### PR TITLE
fixes test errors, but tests are still failing

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.3
 Docile
-Requires
 Compose

--- a/src/GraphLayout.jl
+++ b/src/GraphLayout.jl
@@ -2,10 +2,10 @@ module GraphLayout
     if VERSION < v"0.4.0"
         using Docile
     end
-    using Requires  # to optionally load JuMP
     using Compose  # for plotting features
 
     typealias AdjList{T} Vector{Vector{T}}
+    export AdjList
 
     # Spring-based force layout algorithms
     export layout_spring_adj
@@ -21,8 +21,7 @@ module GraphLayout
     # Heuristic algortihms for tree layout
     include("tree_heur.jl")
     # Optimal algorithms for tree layout, that require JuMP
-    # JuMP will only be loaded if these methods are requested
-    @require JuMP include(joinpath(Pkg.dir("GraphLayout","src","tree_opt.jl")))
+    include("tree_opt.jl")
 
     # Drawing utilities
     export draw_layout_adj

--- a/src/tree_opt.jl
+++ b/src/tree_opt.jl
@@ -4,193 +4,200 @@
 # integer programming solver installed, such as GLPK, Cbc, or one of the
 # commercial solvers like Gurobi or CPLEX
 
-using JuMP
-
-########################################################################
-
-
-@doc """
-    Given a layer assignment, decide a permutation for each layer
-    that minimizes edge crossings using integer programming.
-
-    Based on the IP described in
-      M. Junger, E. K. Lee, P. Mutzel, and T. Odenthal.
-      A polyhedral approach to the multi-layer crossing minimization problem.
-      In G. Di Battista, editor, Graph Drawing: 5th International Symposium,
-      GD ’97, volume 1353 of Lecture Notes in Computer Science, pages 13–24,
-      Rome, Italy, September 1997. Springer-Verlag.
-
-
-    Arguments:
-    adj_list        Directed graph in adjacency list format
-    layers          Assignment of vertices
-    layer_verts     Dictionary of layer => vertices (initial perm.)
-
-    Returns:
-    new_layer_verts An improved dictionary of layer => vertices (opt. perm.)
-""" ->
-function _ordering_ip{T}(adj_list::AdjList{T}, layers, layer_verts)
-    num_layers = maximum(layers)
-
-    m = Model()
-
-    # Define crossing binary variables
-    @defVar(m, c[L=1:num_layers,        # for each layer
-                 i=layer_verts[L],      # for each vertex in this layer
-                 j=adj_list[i],         # and vertex in the next layer
-                 k=layer_verts[L],      # for each vertex in this layer
-                 l=adj_list[k]], Bin)   # and vertex in the next layer
-
-    # Objective: minimize crossings
-    @setObjective(m, Min, sum(c))
-
-    # Define permutation variables for each layer
-    # We'll define for both (i,j) and (j,i), and ensure they consistency
-    # by adding constraints. Presolve in the IP solver will simplify
-    # the problem for us by removing one of the variables.
-    @defVar(m, x[L=1:num_layers, i=layer_verts[L], j=layer_verts[L]], Bin)
-    for L in 1:num_layers
-        for i in layer_verts[L]
-            for j in layer_verts[L]
-                j <= i && continue  # Don't double-add
-                # Ensure x[i,j] and x[j,i] are consistent
-                @addConstraint(m, x[L,i,j] == 1 - x[L,j,i])
-                # And ensure that triples are consistent
-                for k in layer_verts[L]
-                    k <= j && continue
-                    @addConstraint(m, 0 <= x[L,i,j] + x[L,j,k] - x[L,i,k] <= 1)
-                end
-            end
-        end
-    end
-
-    # Link permutations to crossings
-    for L in 1:num_layers-1
-        # For all (i,j)
-        for i in layer_verts[L]
-        for j in adj_list[i]
-            # For all (k,l)
-            for k in layer_verts[L]
-            k == i && continue  # Can't cross if starting from same vertex!
-            for l in adj_list[k]
-                @addConstraint(m, -c[L,i,j,k,l] <= x[L+1,j,l] - x[L,i,k])
-                @addConstraint(m,  c[L,i,j,k,l] >= x[L+1,j,l] - x[L,i,k])
-            end
-            end
-        end
-        end
-    end
-
-    # Solve the IP
-    solve(m)
-
-    # Extract permutation from solution
-    x_sol = getValue(x)
-    new_layer_verts = [L => Int[] for L in 1:num_layers]
-    for L in 1:num_layers
-        old_perm = layer_verts[L]
-        # For each vertex, count the number of times it is "in front"
-        # of the other vertices. The higher this number, the earlier
-        # the vertex appears in the layer.
-        scores = zeros(length(old_perm))
-        for (p,i) in enumerate(old_perm)
-            for j in old_perm
-                i == j && continue
-                if iround(x_sol[L,i,j]) == 1
-                    # i appears before j
-                    scores[p] += 1
-                end
-            end
-        end
-        new_layer_verts[L] = old_perm[sortperm(scores,rev=true)]
-    end
-
-    return new_layer_verts
+try
+    using JuMP
+    nothing
+catch
+    nothing
 end
 
+if isdefined(:JuMP)
+    # """
+    #     Given a layer assignment, decide a permutation for each layer
+    #     that minimizes edge crossings using integer programming.
+    #
+    #     Based on the IP described in
+    #       M. Junger, E. K. Lee, P. Mutzel, and T. Odenthal.
+    #       A polyhedral approach to the multi-layer crossing minimization problem.
+    #       In G. Di Battista, editor, Graph Drawing: 5th International Symposium,
+    #       GD ’97, volume 1353 of Lecture Notes in Computer Science, pages 13–24,
+    #       Rome, Italy, September 1997. Springer-Verlag.
+    #
+    #
+    #     Arguments:
+    #     adj_list        Directed graph in adjacency list format
+    #     layers          Assignment of vertices
+    #     layer_verts     Dictionary of layer => vertices (initial perm.)
+    #
+    #     Returns:
+    #     new_layer_verts An improved dictionary of layer => vertices (opt. perm.)
+    # """ ->
+    function _ordering_ip{T}(adj_list::AdjList{T}, layers, layer_verts)
+        num_layers = maximum(layers)
 
-########################################################################
+        m = Model()
 
+        # Define crossing binary variables
+        @defVar(m, c[L=1:num_layers,        # for each layer
+                     i=layer_verts[L],      # for each vertex in this layer
+                     j=adj_list[i],         # and vertex in the next layer
+                     k=layer_verts[L],      # for each vertex in this layer
+                     l=adj_list[k]], Bin)   # and vertex in the next layer
 
-@doc """
-    Given a layer assignment and permutation, decide the coordinates for
-    each vertex. The objective is to encourage straight edges, especially
-    for longer edges. This function uses an integer program to decide the
-    coordinates (although it is solved as a linear program), as described in
-      Gansner, Emden R., et al.
-      A technique for drawing directed graphs.
-      Software Engineering, IEEE Transactions on 19.3 (1993): 214-230.
+        # Objective: minimize crossings
+        @setObjective(m, Min, sum(c))
 
-    Arguments:
-    adj_list        Directed graph in adjacency list format
-    layers          Assignment of vertices
-    layer_verts     Dictionary of layer => vertices (final perm.)
-    orig_n          Number of original (non-dummy) vertices
-    widths          Width of each vertex
-    xsep            Minimum seperation between each vertex
-
-    Returns:
-    layer_coords    For each layer and vertex, the x-coord
-""" ->
-function _coord_ip{T}(adj_list::AdjList{T}, layers, layer_verts, orig_n, widths, xsep)
-    num_layers = maximum(layers)
-
-    m = Model()
-
-    # One variable for each vertex
-    @defVar(m, x[L=1:num_layers, i=layer_verts[L]] >= 0)
-
-    # Constraint: must respect permutation, and spacign constraint
-    for L in 1:num_layers
-        for i in 1:length(layer_verts[L])-1
-            a = layer_verts[L][i]
-            b = layer_verts[L][i+1]
-            @addConstraint(m, x[L,b] - x[L,a] >= 
-                (widths[a] + widths[b])/2 + xsep)
-        end
-    end
-
-    # Objective: minimize total misalignment
-    # Use the weights from the Ganser paper:
-    #   1 if both nodes "real"
-    #   2 if one of the nodes is "real"
-    #   8 if neither node is "real"
-    # We use absolute distance in the objective so we'll need
-    # auxilary variables for each pair of edges
-    obj = AffExpr()
-    @defVar(m, absdiff[L=1:num_layers-1,
-                        i=layer_verts[L], j=adj_list[i]] >= 0)
-    for L in 1:num_layers-1
-        for i in layer_verts[L]
-            for j in adj_list[i]
-                @addConstraint(m, absdiff[L,i,j] >= x[L,i] - x[L+1,j])
-                @addConstraint(m, absdiff[L,i,j] >= x[L+1,j] - x[L,i])
-                if i > orig_n && j > orig_n
-                    # Both dummy vertices
-                    obj += 8*absdiff[L,i,j]
-                elseif (i <= orig_n && j >  orig_n) ||
-                       (i >  orig_n && j <= orig_n)
-                    # Only one dummy vertix
-                    obj += 2*absdiff[L,i,j]
-                else
-                    # Both real
-                    obj += absdiff[L,i,j]
+        # Define permutation variables for each layer
+        # We'll define for both (i,j) and (j,i), and ensure they consistency
+        # by adding constraints. Presolve in the IP solver will simplify
+        # the problem for us by removing one of the variables.
+        @defVar(m, x[L=1:num_layers, i=layer_verts[L], j=layer_verts[L]], Bin)
+        for L in 1:num_layers
+            for i in layer_verts[L]
+                for j in layer_verts[L]
+                    j <= i && continue  # Don't double-add
+                    # Ensure x[i,j] and x[j,i] are consistent
+                    @addConstraint(m, x[L,i,j] == 1 - x[L,j,i])
+                    # And ensure that triples are consistent
+                    for k in layer_verts[L]
+                        k <= j && continue
+                        @addConstraint(m, 0 <= x[L,i,j] + x[L,j,k] - x[L,i,k] <= 1)
+                    end
                 end
             end
         end
-    end
-    @setObjective(m, Min, obj)
 
-    # Solve it...
-    solve(m)
-
-    # ... and mangle the solution into shape
-    x_sol = getValue(x)
-    locs_x = zeros(length(layers))
-    for L in 1:num_layers
-        for i in layer_verts[L]
-            locs_x[i] = x_sol[L,i]
+        # Link permutations to crossings
+        for L in 1:num_layers-1
+            # For all (i,j)
+            for i in layer_verts[L]
+            for j in adj_list[i]
+                # For all (k,l)
+                for k in layer_verts[L]
+                k == i && continue  # Can't cross if starting from same vertex!
+                for l in adj_list[k]
+                    @addConstraint(m, -c[L,i,j,k,l] <= x[L+1,j,l] - x[L,i,k])
+                    @addConstraint(m,  c[L,i,j,k,l] >= x[L+1,j,l] - x[L,i,k])
+                end
+                end
+            end
+            end
         end
+
+        # Solve the IP
+        solve(m)
+
+        # Extract permutation from solution
+        x_sol = getValue(x)
+        new_layer_verts = [L => Int[] for L in 1:num_layers]
+        for L in 1:num_layers
+            old_perm = layer_verts[L]
+            # For each vertex, count the number of times it is "in front"
+            # of the other vertices. The higher this number, the earlier
+            # the vertex appears in the layer.
+            scores = zeros(length(old_perm))
+            for (p,i) in enumerate(old_perm)
+                for j in old_perm
+                    i == j && continue
+                    if iround(x_sol[L,i,j]) == 1
+                        # i appears before j
+                        scores[p] += 1
+                    end
+                end
+            end
+            new_layer_verts[L] = old_perm[sortperm(scores,rev=true)]
+        end
+
+        return new_layer_verts
     end
-    return locs_x
+
+
+    ########################################################################
+
+
+    # """
+    #     Given a layer assignment and permutation, decide the coordinates for
+    #     each vertex. The objective is to encourage straight edges, especially
+    #     for longer edges. This function uses an integer program to decide the
+    #     coordinates (although it is solved as a linear program), as described in
+    #       Gansner, Emden R., et al.
+    #       A technique for drawing directed graphs.
+    #       Software Engineering, IEEE Transactions on 19.3 (1993): 214-230.
+    #
+    #     Arguments:
+    #     adj_list        Directed graph in adjacency list format
+    #     layers          Assignment of vertices
+    #     layer_verts     Dictionary of layer => vertices (final perm.)
+    #     orig_n          Number of original (non-dummy) vertices
+    #     widths          Width of each vertex
+    #     xsep            Minimum seperation between each vertex
+    #
+    #     Returns:
+    #     layer_coords    For each layer and vertex, the x-coord
+    # """ ->
+    function _coord_ip{T}(adj_list::AdjList{T}, layers, layer_verts, orig_n, widths, xsep)
+        num_layers = maximum(layers)
+
+        m = Model()
+
+        # One variable for each vertex
+        @defVar(m, x[L=1:num_layers, i=layer_verts[L]] >= 0)
+
+        # Constraint: must respect permutation, and spacign constraint
+        for L in 1:num_layers
+            for i in 1:length(layer_verts[L])-1
+                a = layer_verts[L][i]
+                b = layer_verts[L][i+1]
+                @addConstraint(m, x[L,b] - x[L,a] >=
+                    (widths[a] + widths[b])/2 + xsep)
+            end
+        end
+
+        # Objective: minimize total misalignment
+        # Use the weights from the Ganser paper:
+        #   1 if both nodes "real"
+        #   2 if one of the nodes is "real"
+        #   8 if neither node is "real"
+        # We use absolute distance in the objective so we'll need
+        # auxilary variables for each pair of edges
+        obj = AffExpr()
+        @defVar(m, absdiff[L=1:num_layers-1,
+                            i=layer_verts[L], j=adj_list[i]] >= 0)
+        for L in 1:num_layers-1
+            for i in layer_verts[L]
+                for j in adj_list[i]
+                    @addConstraint(m, absdiff[L,i,j] >= x[L,i] - x[L+1,j])
+                    @addConstraint(m, absdiff[L,i,j] >= x[L+1,j] - x[L,i])
+                    if i > orig_n && j > orig_n
+                        # Both dummy vertices
+                        obj += 8*absdiff[L,i,j]
+                    elseif (i <= orig_n && j >  orig_n) ||
+                           (i >  orig_n && j <= orig_n)
+                        # Only one dummy vertix
+                        obj += 2*absdiff[L,i,j]
+                    else
+                        # Both real
+                        obj += absdiff[L,i,j]
+                    end
+                end
+            end
+        end
+        @setObjective(m, Min, obj)
+
+        # Solve it...
+        solve(m)
+
+        # ... and mangle the solution into shape
+        x_sol = getValue(x)
+        locs_x = zeros(length(layers))
+        for L in 1:num_layers
+            for i in layer_verts[L]
+                locs_x[i] = x_sol[L,i]
+            end
+        end
+        return locs_x
+    end
+else
+    _coord_ip(_...) = error("Requires JuMP")
+    _ordering_ip(_...) = error("Requires JuMP")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FactCheck
 using GraphLayout
+using JuMP
 
 srand(1)
 


### PR DESCRIPTION
The tests are failing with sizes being exactly twice (or half?) what the tests say they should be. An excerpt:

```
ERROR: LoadError: Generated output differs from cached test output:
pentagon_labeled.svg
pentagon_longarrows.svg
pentagon_noarrows.svg
pentagon_spring.svg
pentagon_stress.svg
random_spring.svg
random_spring_color.svg
random_stress.svg
tree_1.svg
tree_2.svg

pentagon_labeled.svg:
5c5
<      width="101.6mm" height="101.6mm" viewBox="0 0 101.6 101.6"
---
>      width="203.2mm" height="203.2mm" viewBox="0 0 203.2 203.2"
12,71c12,71
<   <path fill="none" d="M18.27,30.27 L 12.64 29.47"/>
<   <path fill="none" d="M16.44,33.7 L 12.64 29.47"/>
<   <path fill="none" d="M93.13,72.43 L 12.64 29.47"/>
<   <path fill="none" d="M39.2,88.14 L 34.73 91.65"/>
...
----
>   <path fill="none" d="M36.53,60.54 L 25.28 58.94"/>
>   <path fill="none" d="M32.87,67.39 L 25.28 58.94"/>
>   <path fill="none" d="M186.27,144.86 L 25.28 58.94"/>
>   <path fill="none" d="M78.39,176.28 L 69.47 183.31"/>
...
```