### PR TITLE
Minimal changes to run julia 0.4 without warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3
 Docile
 Requires
 Compose
+Compat

--- a/src/GraphLayout.jl
+++ b/src/GraphLayout.jl
@@ -1,9 +1,13 @@
+
+VERSION >= v"0.4.0" && __precompile__(true)
+
 module GraphLayout
     if VERSION < v"0.4.0"
         using Docile
     end
     using Requires  # to optionally load JuMP
     using Compose  # for plotting features
+    using Compat # for v0.3 compatibility
 
     typealias AdjList{T} Vector{Vector{T}}
 
@@ -21,8 +25,10 @@ module GraphLayout
     # Heuristic algortihms for tree layout
     include("tree_heur.jl")
     # Optimal algorithms for tree layout, that require JuMP
-    # JuMP will only be loaded if these methods are requested
-    @require JuMP include(joinpath(Pkg.dir("GraphLayout","src","tree_opt.jl")))
+    # These methods will be loaded when JuMP is loaded
+    _ordering_ip(args...) = 
+        error("JuMP package must be loaded for optimization tree layout")
+    @require JuMP include("tree_opt.jl")
 
     # Drawing utilities
     export draw_layout_adj

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -1,6 +1,8 @@
 using Compose
 import Colors
-typealias ComposeColor Union(Colors.Color, Colors.AlphaColor, Colors.String)
+@compat typealias ComposeColor Union{Colors.Color, 
+                                     Colors.AlphaColor, 
+                                     Colors.AbstractString}
 
 @doc """
 Given an adjacency matrix and two vectors of X and Y coordinates, returns
@@ -25,7 +27,7 @@ function compose_layout_adj{S, T<:Real}(
     adj_matrix::Array{S,2},
     locs_x::Vector{T}, locs_y::Vector{T};
     labels::Vector=Any[],
-    filename::String="",
+    filename::AbstractString="",
     labelc::ComposeColor="#000000",
     nodefillc::ComposeColor="#AAAAFF",
     nodestrokec::ComposeColor="#BBBBBB",
@@ -137,7 +139,7 @@ function draw_layout_adj{S, T<:Real}(
     adj_matrix::Array{S,2},
     locs_x::Vector{T}, locs_y::Vector{T};
     labels::Vector=Any[],
-    filename::String="",
+    filename::AbstractString="",
     labelc::ComposeColor="#000000",
     nodefillc::ComposeColor="#AAAAFF",
     nodestrokec::ComposeColor="#BBBBBB",

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -1,3 +1,12 @@
+# Uses a macro to switch between .abs and .value depending on Compose version
+macro raw_measure(m)
+    if Pkg.installed("Compose") > v"0.3.18"
+        return :($m.value)
+    else
+        return :($m.abs)
+    end
+end
+
 @doc """
     Hierachical drawing of directed graphs inspired by the Sugiyama framework.
     In particular see Chapter 13 of 'Hierachical Drawing Algorithms' from
@@ -99,7 +108,8 @@ function layout_tree{T}(adj_list::AdjList{T},
     if length(labels) == orig_n
         extents = text_extents("sans",10pt,labels...)
         for (i,(width,height)) in enumerate(extents)
-            widths[i], heights[i] = width.abs, height.abs
+            widths[i] = @raw_measure width
+            heights[i] = @raw_measure height
         end
     end
     locs_x = _coord_ip(adj_list, layers, layer_verts, orig_n, widths, xsep)

--- a/src/tree_opt.jl
+++ b/src/tree_opt.jl
@@ -96,7 +96,7 @@ function _ordering_ip{T}(adj_list::AdjList{T}, layers, layer_verts)
         for (p,i) in enumerate(old_perm)
             for j in old_perm
                 i == j && continue
-                if iround(x_sol[L,i,j]) == 1
+                if round(Integer, x_sol[L,i,j]) == 1
                     # i appears before j
                     scores[p] += 1
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FactCheck
 using GraphLayout
+using JuMP # Needed to trigger @require macro
 
 srand(1)
 
@@ -11,7 +12,7 @@ facts("Render a pentagon") do
         draw_layout_adj(adj_matrix, loc_x, loc_y, filename="pentagon_spring.svg")
 
         draw_layout_adj(adj_matrix, loc_x, loc_y, filename="pentagon_labeled.svg",
-        	labels=[1:5], labelsize=2.0)
+        	labels=collect(1:5), labelsize=2.0)
         draw_layout_adj(adj_matrix, loc_x, loc_y, filename="pentagon_noarrows.svg",
         	arrowlengthfrac=0.0)
         draw_layout_adj(adj_matrix, loc_x, loc_y, filename="pentagon_longarrows.svg",
@@ -56,7 +57,7 @@ include("test_tree.jl")
 #Check that output agrees with cached data
 #Compare with cached output
 cachedout = joinpath(Pkg.dir("GraphLayout"), "test", "examples")
-differentfiles = String[]
+differentfiles = AbstractString[]
 if VERSION > v"0.4.0-" #Changes to RNG mean that the tests only work on 0.4
     for output in readdir(".")
         endswith(output, ".svg") || continue


### PR DESCRIPTION
This PR is much simpler compared with the previous one and doesn't touch the test code much. Syntax is updated to the v0.4 form. The Compat dependency is added to retain julia 0.3 compatibility. JuMP optional loading is clarified. The `@raw_measure` macro allows layout_tree to work with versions of Compose compatible with julia 0.3 as well as the current version of Compose.